### PR TITLE
Fix typo in initializer

### DIFF
--- a/lib/generators/heya/install/templates/initializer.rb.tt
+++ b/lib/generators/heya/install/templates/initializer.rb.tt
@@ -8,7 +8,7 @@ Heya.configure do |config|
   # Campaign priority. When a user is added to multiple campaigns, they are
   # sent in this order. Campaigns are sent in the order that the users were
   # added if no priority is configured.
-  # config.campaings.priority = [
+  # config.campaigns.priority = [
   #   "FirstCampaign",
   #   "SecondCampaign",
   #   "ThirdCampaign"


### PR DESCRIPTION
After running the generator, the initializer has a typo in that may cause issues for new users